### PR TITLE
feat: Add download sample image button to attendance extractor

### DIFF
--- a/src/app/teacher/dashboard/admin-work/attendance-extractor.tsx
+++ b/src/app/teacher/dashboard/admin-work/attendance-extractor.tsx
@@ -16,6 +16,7 @@ const AttendanceExtractor = () => {
   const [selectedImage, setSelectedImage] = useState(null);
   const [imagePreview, setImagePreview] = useState(null);
   const [dragActive, setDragActive] = useState(false);
+  const [isBlinking, setIsBlinking] = useState(false);
   const resultsEndRef = useRef(null);
   const fileInputRef = useRef(null);
 
@@ -28,6 +29,14 @@ const AttendanceExtractor = () => {
   useEffect(() => {
     scrollToBottom();
   }, [results]);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setIsBlinking(prev => !prev);
+    }, 500);
+
+    return () => clearInterval(intervalId);
+  }, []);
 
   const handleImageSelect = (file) => {
     if (file && file.type.startsWith('image/')) {
@@ -71,6 +80,16 @@ const AttendanceExtractor = () => {
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
+  };
+
+  const handleDownloadSampleImage = () => {
+    const imageUrl = 'https://firebasestorage.googleapis.com/v0/b/role-auth-7bc43.firebasestorage.app/o/sample%2Fsample%20attedence%20register%20capture.jpeg?alt=media&token=de925fe9-7c26-46fd-9210-1b86f76f7061';
+    const link = document.createElement('a');
+    link.href = imageUrl;
+    link.download = "sample_attendance_register.jpeg";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   };
 
   const convertImageToBase64 = (file) => {
@@ -363,6 +382,15 @@ const AttendanceExtractor = () => {
                 >
                   <Upload className="w-4 h-4 inline mr-2" />
                   Choose File
+                </button>
+                <button
+                  onClick={handleDownloadSampleImage}
+                  className={`mt-4 px-4 py-2 rounded-lg transition-colors flex items-center justify-center text-white ${
+                    isBlinking ? 'bg-red-700' : 'bg-red-500'
+                  } hover:bg-red-600`}
+                >
+                  <Download className="w-4 h-4 inline mr-2" />
+                  Download Sample Image
                 </button>
                 <p className="text-xs text-gray-500 mt-2">Supports JPG, PNG, GIF, WebP</p>
               </div>

--- a/src/app/teacher/dashboard/admin-work/attendance-extractor.tsx
+++ b/src/app/teacher/dashboard/admin-work/attendance-extractor.tsx
@@ -82,33 +82,16 @@ const AttendanceExtractor = () => {
     }
   };
 
-  const handleDownloadSampleImage = async () => {
+  const handleDownloadSampleImage = () => {
     const imageUrl = 'https://firebasestorage.googleapis.com/v0/b/role-auth-7bc43.firebasestorage.app/o/sample%2Fsample%20attedence%20register%20capture.jpeg?alt=media&token=de925fe9-7c26-46fd-9210-1b86f76f7061';
-    let objectUrl = null;
-
-    try {
-      const response = await fetch(imageUrl);
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      const blob = await response.blob();
-      objectUrl = URL.createObjectURL(blob);
-
-      const link = document.createElement('a');
-      link.href = objectUrl;
-      link.download = "sample_attendance_register.jpeg";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-
-    } catch (error) {
-      console.error("Error downloading sample image:", error);
-      showCustomMessageBox("Failed to download sample image. Please check the console for details.", true);
-    } finally {
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
-    }
+    const link = document.createElement('a');
+    link.href = imageUrl;
+    link.download = "sample_attendance_register.jpeg";
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   };
 
   const convertImageToBase64 = (file) => {

--- a/src/app/teacher/dashboard/admin-work/attendance-extractor.tsx
+++ b/src/app/teacher/dashboard/admin-work/attendance-extractor.tsx
@@ -82,14 +82,33 @@ const AttendanceExtractor = () => {
     }
   };
 
-  const handleDownloadSampleImage = () => {
+  const handleDownloadSampleImage = async () => {
     const imageUrl = 'https://firebasestorage.googleapis.com/v0/b/role-auth-7bc43.firebasestorage.app/o/sample%2Fsample%20attedence%20register%20capture.jpeg?alt=media&token=de925fe9-7c26-46fd-9210-1b86f76f7061';
-    const link = document.createElement('a');
-    link.href = imageUrl;
-    link.download = "sample_attendance_register.jpeg";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    let objectUrl = null;
+
+    try {
+      const response = await fetch(imageUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const blob = await response.blob();
+      objectUrl = URL.createObjectURL(blob);
+
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = "sample_attendance_register.jpeg";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+    } catch (error) {
+      console.error("Error downloading sample image:", error);
+      showCustomMessageBox("Failed to download sample image. Please check the console for details.", true);
+    } finally {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    }
   };
 
   const convertImageToBase64 = (file) => {


### PR DESCRIPTION
This commit introduces a new "Download Sample Image" button to the attendance extractor feature.

The button is styled to be red and has a blinking animation to attract your attention. Clicking the button downloads a sample attendance register image.

The download is handled client-side and does not affect the current application state.