### PR TITLE
feat: Display your profile picture and logout in sidebar

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -12,12 +12,15 @@ import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
+// Tooltip related imports are already present
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useAuth } from '@/context/auth-context'; 
+import LogoutButton from '@/components/auth/logout-button'; 
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -369,16 +372,54 @@ const SidebarFooter = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
 >(({ className, ...props }, ref) => {
+  const { user } = useAuth(); 
+  const { state: sidebarState, isMobile } = useSidebar(); 
+
   return (
     <div
       ref={ref}
       data-sidebar="footer"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn("flex flex-col p-2", className)}
       {...props}
-    />
-  )
-})
-SidebarFooter.displayName = "SidebarFooter"
+    >
+      {user && ( 
+        <div className="mt-auto border-t border-sidebar-border pt-2 space-y-1">
+          <SidebarMenuItem> 
+            <div className="flex items-center w-full p-1">
+              {user.photoURL && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <img
+                      src={user.photoURL}
+                      alt={user.displayName || 'Profile'}
+                      className="w-7 h-7 rounded-full mr-2 flex-shrink-0"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="right" align="center" hidden={sidebarState === 'expanded' || isMobile}>
+                    <p>{user.displayName || 'User'}</p>
+                    {user.email && <p className="text-xs text-muted-foreground">{user.email}</p>}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+              <div className="flex flex-col overflow-hidden group-data-[state=collapsed]:hidden">
+                <span className="text-sm font-medium truncate">
+                  {user.displayName || 'User'}
+                </span>
+                {user.email && (
+                  <span className="text-xs text-sidebar-foreground/70 truncate">
+                    {user.email}
+                  </span>
+                )}
+              </div>
+            </div>
+          </SidebarMenuItem>
+          <LogoutButton />
+        </div>
+      )}
+    </div>
+  );
+});
+SidebarFooter.displayName = "SidebarFooter";
 
 const SidebarSeparator = React.forwardRef<
   React.ElementRef<typeof Separator>,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface UserProfile {
   uid: string;
   email: string | null;
   displayName: string | null;
+  photoURL?: string; // Added field
   role: UserRole | null;
 }
 


### PR DESCRIPTION
Integrates Google profile pictures into the user authentication flow and displays them in the sidebar.

Key changes:
- Updated `UserProfile` type to include `photoURL`.
- Modified `auth-context.tsx` to fetch, store in Firestore, and manage `photoURL` in your state. Profile picture URL is updated from Google upon each sign-in.
- Enhanced `SidebarFooter` in `sidebar.tsx` to:
  - Display your profile picture (if available) at the bottom-left.
  - Show your display name next to the picture when the sidebar is expanded (hidden when collapsed).
  - Provide a tooltip with your name and email when hovering over the profile picture in the collapsed sidebar state.
  - Include the existing `LogoutButton` component, which correctly adapts to expanded/collapsed sidebar states.
- Ensured the layout is responsive and handles cases where `photoURL` might be missing.

The logout button is now co-located with your profile information for improved user experience.