### PR TITLE
feat: Integrate Google Analytics

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type {Metadata} from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { AuthProvider } from '@/context/auth-context';
+import Analytics from '@/components/analytics'; // Import Analytics component
 import './globals.css';
 
 const geistSans = Geist({
@@ -29,6 +30,7 @@ export default function RootLayout({
         <AuthProvider>
           {children}
         </AuthProvider>
+        <Analytics /> {/* Add Analytics component */}
       </body>
     </html>
   );

--- a/src/components/analytics.tsx
+++ b/src/components/analytics.tsx
@@ -1,0 +1,51 @@
+// src/components/analytics.tsx
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import Script from "next/script";
+import { useEffect } from "react";
+
+const pageview = (url: string) => {
+  // @ts-ignore
+  window.dataLayer.push({
+    event: "pageview",
+    page: url,
+  });
+};
+
+export default function Analytics() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (pathname) {
+      pageview(pathname);
+    }
+  }, [pathname, searchParams]);
+
+  return (
+    <>
+      <noscript>
+        <iframe
+          src={`https://www.googletagmanager.com/ns.html?id=GTM-W2W2N2N`}
+          height="0"
+          width="0"
+          style={{ display: "none", visibility: "hidden" }}
+        />
+      </noscript>
+      <Script
+        id="gtm-script"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-W2W2N2N');
+  `,
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
I've added Google Analytics to the project.

- I created an `Analytics` component to encapsulate the GA script.
- I used `next/script` for efficient script loading.
- I integrated the component into the main application layout.
- It now tracks page views using `window.dataLayer.push`.
- I also included a noscript fallback.