### PR TITLE
feat: Add WYSIWYG editor for help text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
+        "react-simple-wysiwyg": "^3.4.0",
         "react-spinners": "^0.14.1",
         "recharts": "^2.15.1",
         "tailwind-merge": "^3.0.1",
@@ -11856,6 +11857,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-simple-wysiwyg": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-simple-wysiwyg/-/react-simple-wysiwyg-3.4.0.tgz",
+      "integrity": "sha512-2RYJoUBqXOH+i8Q3vUQCg8O0ZRlb3RsZRpHNQwGLLFOosscdT4grEcPZbrB2xrq0ir/5N2MitRp/sHzxJu6a7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/react-smooth": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
+    "react-simple-wysiwyg": "^3.4.0",
     "react-spinners": "^0.14.1",
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",

--- a/src/app/student/assessment/page.tsx
+++ b/src/app/student/assessment/page.tsx
@@ -297,7 +297,7 @@ export default function StudentAssessmentPage() {
               )}
               <div className="mt-6 p-4 border rounded-lg bg-gray-50">
                   <h3 className="block text-lg font-semibold mb-2">{currentStep.question.title}</h3>
-                  <p className="text-sm text-muted-foreground">{currentStep.question.helpText}</p>
+                  <div className="text-sm text-muted-foreground" dangerouslySetInnerHTML={{ __html: currentStep.question.helpText }} />
               </div>
             </div>
           );
@@ -312,7 +312,7 @@ export default function StudentAssessmentPage() {
             )}
             <div className="mt-6">
                 <label className="block text-lg font-semibold mb-2">{currentStep.question.title}</label>
-                <p className="text-sm text-muted-foreground mb-3">{currentStep.question.helpText}</p>
+                <div className="text-sm text-muted-foreground mb-3" dangerouslySetInnerHTML={{ __html: currentStep.question.helpText }} />
                 <Textarea
                   rows={8}
                   placeholder="Your answer..."

--- a/src/app/teacher/assessment-admin/page.tsx
+++ b/src/app/teacher/assessment-admin/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import Editor from 'react-simple-wysiwyg';
 import { Plus, Trash2, ChevronUp, ChevronDown } from 'lucide-react';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -222,11 +223,11 @@ export default function AssessmentAdminPage() {
                   className="mb-2 font-bold w-full"
                 />
               </div>
-              <Textarea
-                placeholder="Help Text"
-                value={q.helpText}
+              <Editor
+                value={q.helpText || ''}
                 onChange={(e) => handleQuestionChange('s1', q.id, 'helpText', e.target.value)}
-              />
+              >
+              </Editor>
               <div className="flex items-center space-x-2 mt-2">
                 <Checkbox
                   id={`isInstruction-s1-${q.id}`}
@@ -274,11 +275,11 @@ export default function AssessmentAdminPage() {
                   className="mb-2 font-bold w-full"
                 />
               </div>
-              <Textarea
-                placeholder="Help Text"
-                value={q.helpText}
+              <Editor
+                value={q.helpText || ''}
                 onChange={(e) => handleQuestionChange('goalSetting', q.id, 'helpText', e.target.value)}
-              />
+              >
+              </Editor>
               <div className="flex items-center space-x-2 mt-2">
                 <Checkbox
                   id={`isInstruction-goalSetting-${q.id}`}
@@ -326,11 +327,11 @@ export default function AssessmentAdminPage() {
                   className="mb-2 font-bold w-full"
                 />
               </div>
-              <Textarea
-                placeholder="Help Text"
-                value={q.helpText}
+              <Editor
+                value={q.helpText || ''}
                 onChange={(e) => handleQuestionChange('goal', q.id, 'helpText', e.target.value)}
-              />
+              >
+              </Editor>
               <div className="flex items-center space-x-2 mt-2">
                 <Checkbox
                   id={`isInstruction-goal-${q.id}`}
@@ -377,11 +378,11 @@ export default function AssessmentAdminPage() {
                   className="mb-2 font-bold w-full"
                 />
               </div>
-              <Textarea
-                placeholder="Help Text"
-                value={q.helpText}
+              <Editor
+                value={q.helpText || ''}
                 onChange={(e) => handleQuestionChange('s2', q.id, 'helpText', e.target.value)}
-              />
+              >
+              </Editor>
               <div className="flex items-center space-x-2 mt-2">
                 <Checkbox
                   id={`isInstruction-s2-${q.id}`}


### PR DESCRIPTION
This commit introduces a WYSIWYG editor for the help text fields in the assessment creation page. This allows for rich text formatting of the help text, which will improve the user experience.

The following changes were made:
- Added the `react-simple-wysiwyg` dependency.
- Replaced the `Textarea` component with the `Editor` component from `react-simple-wysiwyg` in the assessment admin page.
- Updated the student assessment page to render the HTML content of the help text.