### PR TITLE
feat: Allow teachers to update goal setting instructions

### DIFF
--- a/src/app/student/assessment/page.tsx
+++ b/src/app/student/assessment/page.tsx
@@ -84,6 +84,7 @@ export default function StudentAssessmentPage() {
                 section1Questions: templateData.section1Questions || [],
                 goalQuestions: templateData.goalQuestions || [],
                 goalSettingQuestions: templateData.goalSettingQuestions || [],
+                goalSettingInstructions: templateData.goalSettingInstructions || `Define up to ${MAX_GOALS} personal or professional goals.`,
                 section2FixedQuestions: templateData.section2FixedQuestions || [],
               };
               setDoc(userAssessmentRef, newAssessment).then(() => {
@@ -262,7 +263,7 @@ export default function StudentAssessmentPage() {
         return (
           <div>
             <h2 className="text-2xl font-bold mb-6">{currentStep.sectionTitle}</h2>
-            <p className="mb-4 text-muted-foreground">Define up to {MAX_GOALS} personal or professional goals.</p>
+            <div className="mb-4 text-muted-foreground" dangerouslySetInnerHTML={{ __html: assessmentData.goalSettingInstructions || `Define up to ${MAX_GOALS} personal or professional goals.` }} />
             <div className="space-y-4">
               {goals.map((goal, index) => (
                   <div key={index} className="flex items-center gap-2">

--- a/src/app/teacher/assessment-admin/page.tsx
+++ b/src/app/teacher/assessment-admin/page.tsx
@@ -23,6 +23,7 @@ export default function AssessmentAdminPage() {
   const [section2FixedQuestions, setSection2FixedQuestions] = useState<Question[]>([]);
   const [goalQuestions, setGoalQuestions] = useState<Question[]>([]);
   const [goalSettingQuestions, setGoalSettingQuestions] = useState<Question[]>([]);
+  const [goalSettingInstructions, setGoalSettingInstructions] = useState('');
 
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -39,6 +40,7 @@ export default function AssessmentAdminPage() {
             setGoalQuestions(data.goalQuestions || []);
             setSection2FixedQuestions(data.section2FixedQuestions || []);
             setGoalSettingQuestions(data.goalSettingQuestions || []);
+            setGoalSettingInstructions(data.goalSettingInstructions || 'Define up to 8 personal or professional goals.');
           } else {
              setError('No template found. Saving will create a new one.');
           }
@@ -73,6 +75,7 @@ export default function AssessmentAdminPage() {
           goalQuestions: goalQuestions.map(a),
           section2FixedQuestions: section2FixedQuestions.map(a),
           goalSettingQuestions: goalSettingQuestions.map(a),
+          goalSettingInstructions,
           updatedAt: serverTimestamp(),
         },
         { merge: true }
@@ -196,6 +199,20 @@ export default function AssessmentAdminPage() {
             Here you can define the questions for the personality assessment. Changes will apply to new assessments.
           </p>
            {error && <p className="text-yellow-600 mt-4">{error}</p>}
+        </CardContent>
+      </Card>
+
+      {/* Goal Setting Instructions */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Goal Setting Instructions</CardTitle>
+          <p className="text-sm text-muted-foreground">This text will be shown to the user when they are defining their goals.</p>
+        </CardHeader>
+        <CardContent>
+          <Editor
+            value={goalSettingInstructions}
+            onChange={(e) => setGoalSettingInstructions(e.target.value)}
+            />
         </CardContent>
       </Card>
 


### PR DESCRIPTION
This commit introduces the ability for teachers to customize the instructions that students see when setting their goals in the assessment.

- A new `goalSettingInstructions` field has been added to the `personalityAssessmentTemplates` in Firestore.
- The teacher's assessment admin page now includes a rich text editor to modify these instructions.
- The student's assessment page now dynamically displays these custom instructions, with a fallback to the original hardcoded text.